### PR TITLE
Distinction voie droite/gauche champ "local"

### DIFF
--- a/schema_amenagements_cyclables.json
+++ b/schema_amenagements_cyclables.json
@@ -128,6 +128,17 @@
                                     3
                                 ]
                             },
+                             "local_d": {
+                                "type": "string",
+                                "description": "Emplacement de l'aménagement sur la voie de droite",
+                                "examples": [
+                                    "TROTTOIR"
+                                ],
+                                "enum": [
+                                    "TROTTOIR",
+                                    "CHAUSSEE"
+                                ]
+                                 },
                             "ame_g": {
                                 "type": "string",
                                 "description": "Type d'aménagement présent sur la voie de gauche",
@@ -185,9 +196,9 @@
                                     4.1
                                 ]
                             },
-                            "local_ame": {
+                            "local_g": {
                                 "type": "string",
-                                "description": "Emplacement de l'aménagement",
+                                "description": "Emplacement de l'aménagement sur la voie de gauche",
                                 "examples": [
                                     "TROTTOIR"
                                 ],


### PR DESCRIPTION
Passage de "local_ame" à "local_d" et "local_g" afin de permettra aux producteurs de différencier l'emplacement de l'aménagement sur la voie de droite de celui sur la voie de gauche