### PR TITLE
Correction coquille ame_g

### DIFF
--- a/schema_amenagements_cyclables.json
+++ b/schema_amenagements_cyclables.json
@@ -175,7 +175,7 @@
                                     "COULOIR BUS+VELO",
                                     "RAMPE",
                                     "GOULOTTE",
-                                    "AMENAGEMENT MIXTES PIETON VELO HORS VOIE VERTE",
+                                    "AMENAGEMENT MIXTE PIETON VELO HORS VOIE VERTE",
                                     "CHAUSSEE A VOIE CENTRALE BANALISEE",
                                     "ACCOTEMENT REVENTU HORS CVCB",
                                     "AUCUN",


### PR DESCRIPTION
Correction coquille ame_g : passage d'"AMENAGEMENT MIXTES" à "AMENAGEMENT MIXTE"