### PR TITLE
MAJ des infos sur V&T

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,6 +3,7 @@ name: Vérification du respect des spécifications
 on:
   push:
   workflow_dispatch:
+  pull_request:
 
 jobs:
   build:

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 venv
+.DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Ce fichier répertorie les changements entre différentes versions d'un schéma
 
+## Version 0.3.5 - 2024-10-04
+
+Evolution de la documentation
+
 ## Version 0.3.4 - 2023-03-28
 
 Correction du type du champ "date_maj" et ajout d'une vérification pour ce champ 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Les jeux de données seront publiés au format GeoJSON. Certains champs sont obl
 
 Les producteurs pourront saisir leurs données sur :
 - des outils internes ;
-- [OpenStreetMap](https://www.openstreetmap.org) (OSM);
+- [OpenStreetMap](https://www.openstreetmap.org) (OSM) ;
 - les outils développés par Vélo & Territoires à savoir :
     - Un [gabarit au format shapefile](https://github.com/etalab/schema-amenagements-cyclables/blob/master/tools/AC_TEMPLATE_SHP_QGIS.zip) pour QGIS ;
     - Un [script SQL pour la création d’une base de données Postgres/PostGIS](https://github.com/etalab/schema-amenagements-cyclables/blob/master/tools/AC_SQL_POSTGIS.zip) « vierge ».
@@ -54,7 +54,9 @@ Les producteurs pourront :
 - demander à Géovélo de convertir leurs données vers le schéma national ;
 - publier directement sur OpenStreetMap afin que Géovélo se charge de la conversion vers le schéma national et de la publication sur data.gouv.fr.
 
-Nous préconisons aux producteurs de données de publier leurs fichiers avec la règle de nommage suivante : `amenagementcyclable_nom.geojson` avec nom étant le nom de la collectivité productrice des données, par exemple `amenagementcyclable_ain.geojson`. **Nous invitons également les producteurs de données à sélectionner "schéma d'aménagements cyclables" dans la liste déroulante de la section "schema" sur data.gouv.fr lorsqu'ils publieront leurs fichiers.**
+Nous préconisons aux producteurs de données de publier leurs fichiers avec la règle de nommage suivante : `amenagementcyclable_nom.geojson` avec nom étant le nom de la collectivité productrice des données, par exemple `amenagementcyclable_ain.geojson`.
+
+**Nous invitons également les producteurs de données à sélectionner "schéma d'aménagements cyclables" dans la liste déroulante de la section "schema" sur data.gouv.fr lorsqu'ils publieront leurs fichiers.**
 
 En cas de mise à jour d’un fichier déjà intégré à la base consolidée, il est recommandé de prévenir l’équipe transport.data.gouv.fr qui s’assurera de l'actualisation du fichier en question et de son intégration dans la base consolidée à l'adresse : contact@transport.beta.gouv.fr
 
@@ -64,7 +66,7 @@ Cette base de données ainsi construite est issue de l’assemblage de fichiers 
 
 Trois bases seront publiées sur transport.data.gouv.fr :
 - une base nationale regroupant les données publiées par les collectivités sur data.gouv.fr ;
-- une [base rassemblant les données publiées sur OSM](https://transport.data.gouv.fr/datasets/amenagements-cyclables-france-metropolitaine/). Géovélo sera en charge de l'extraction de ces données et de leur mise à jour mensuelle ;
+- une [base rassemblant les données publiées sur ](https://transport.data.gouv.fr/datasets/amenagements-cyclables-france-metropolitaine/). Géovélo sera en charge de l'extraction de ces données et de leur mise à jour mensuelle ;
 - une base nationale consolidant les données publiées par les collectivités sur data.gouv.fr et celles publiées sur OSM. Cette base est hébergée par Vélo & Territoires et accessible via une carte en ligne à l'adresse suivante : [Velodatamap - carte aménagements](https://velodatamap.velo-territoires.org/vmap/dashboard/map?map_id=14).
 
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Nous préconisons aux producteurs de données de publier leurs fichiers avec la 
 
 **Nous invitons également les producteurs de données à sélectionner "schéma d'aménagements cyclables" dans la liste déroulante de la section "schema" sur data.gouv.fr lorsqu'ils publieront leurs fichiers.**
 
-En cas de mise à jour d’un fichier déjà intégré à la base consolidée, il est recommandé de prévenir l’équipe transport.data.gouv.fr qui s’assurera de l'actualisation du fichier en question et de son intégration dans la base consolidée à l'adresse : contact@transport.beta.gouv.fr
+En cas de mise à jour d’un fichier déjà intégré à la base consolidée, il est recommandé de prévenir l’équipe transport.data.gouv.fr qui s’assurera de l'actualisation du fichier en question et de son intégration dans la base consolidée à l'adresse : contact@transport.data.gouv.fr
 
 ## Consolidation
 

--- a/README.md
+++ b/README.md
@@ -35,13 +35,12 @@ Attention : ce jeu de données ne concerne pas le stationnement cyclable. Vous t
 
 Les jeux de données seront publiés au format GeoJSON. Certains champs sont obligatoires et d'autres optionnels. Les champs obligatoires doivent être complétés. Pour les champs optionnels, nous recommandons de [ne pas faire apparaître le champ pour l'aménagement concerné lorsqu'il n'y a aucune valeur à renseigner](https://doc.transport.data.gouv.fr/producteurs/amenagements-cyclables/foire-a-questions#mon-fichier-nest-pas-valide-car-il-contient-des-valeurs-null-comment-corriger-cela) ou d'indiquer la valeur `null` (la chaine de caractères `"null"` n'est pas acceptée).
 
-Les producteurs pourront saisir leurs données sur :
-- des outils internes ;
-- [OpenStreetMap](https://www.openstreetmap.org) (OSM) ;
-- les outils développés par Vélo & Territoires à savoir :
+Les producteurs peuvent saisir leurs données sur :
+- leurs logiciels internes, avec l'aide des outils développés par Vélo & Territoires, à savoir : 
     - Un [gabarit au format shapefile](https://github.com/etalab/schema-amenagements-cyclables/blob/master/tools/AC_TEMPLATE_SHP_QGIS.zip) pour QGIS ;
     - Un [script SQL pour la création d’une base de données Postgres/PostGIS](https://github.com/etalab/schema-amenagements-cyclables/blob/master/tools/AC_SQL_POSTGIS.zip) « vierge ».
- 
+- la base de données OpenStreetMap (OSM).
+
 Ces outils sont hébergés dans le dossier [tools](https://github.com/etalab/schema-amenagements-cyclables/tree/master/tools) de ce répertoire. Pour toute question sur ces outils, vous pouvez contacter la cellule SIG de Vélo & Territoires à cette adresse : sig@velo-territoires.org
 
 
@@ -64,8 +63,7 @@ En cas de mise à jour d’un fichier déjà intégré à la base consolidée, i
 
 Cette base de données ainsi construite est issue de l’assemblage de fichiers de données transmis par des producteurs. Nous tenons à les remercier pour leur travail de normalisation des fichiers. 
 
-Trois bases seront publiées sur transport.data.gouv.fr :
-- une base nationale regroupant les données publiées par les collectivités sur data.gouv.fr ;
+Deux bases seront publiées sur transport.data.gouv.fr :
 - une [base rassemblant les données publiées sur ](https://transport.data.gouv.fr/datasets/amenagements-cyclables-france-metropolitaine/). Géovélo sera en charge de l'extraction de ces données et de leur mise à jour mensuelle ;
 - une base nationale consolidant les données publiées par les collectivités sur data.gouv.fr et celles publiées sur OSM. Cette base est hébergée par Vélo & Territoires et accessible via une carte en ligne à l'adresse suivante : [Velodatamap - carte aménagements](https://velodatamap.velo-territoires.org/vmap/dashboard/map?map_id=14).
 

--- a/README.md
+++ b/README.md
@@ -38,12 +38,11 @@ Les jeux de données seront publiés au format GeoJSON. Certains champs sont obl
 Les producteurs pourront saisir leurs données sur :
 - des outils internes ;
 - OpenStreetMap (OSM); 
-- les outils développés par Vélo & Territoires à savoir, 
-- un [WebSIG](https://on3v.veremes.net/vmap/?mode_id=vmap&map_id=31&token=publictoken#) ;
-- Un [gabarit au format shapefile](https://github.com/etalab/schema-amenagements-cyclables/blob/master/tools/AC_TEMPLATE_SHP_QGIS.zip) pour QGIS ;
-- Un [script SQL pour la création d’une base de données Postgres/PostGIS](https://github.com/etalab/schema-amenagements-cyclables/blob/master/tools/AC_SQL_POSTGIS.zip) « vierge ».
-
-Ces outils sont hébergés dans le dossier [tools](https://github.com/etalab/schema-amenagements-cyclables/tree/master/tools) de ce répertoire. Pour une demande d'accès au WebSIG ou toute autre question sur ces outils, vous pouvez contacter Fabien Commeaux de Vélo & Territoires à cette adresse : fabien.commeaux@velo-territoires.org
+- les outils développés par Vélo & Territoires à savoir :
+    - Un [gabarit au format shapefile](https://github.com/etalab/schema-amenagements-cyclables/blob/master/tools/AC_TEMPLATE_SHP_QGIS.zip) pour QGIS ;
+    - Un [script SQL pour la création d’une base de données Postgres/PostGIS](https://github.com/etalab/schema-amenagements-cyclables/blob/master/tools/AC_SQL_POSTGIS.zip) « vierge ».
+ 
+Ces outils sont hébergés dans le dossier [tools](https://github.com/etalab/schema-amenagements-cyclables/tree/master/tools) de ce répertoire. Pour toute question sur ces outils, vous pouvez contacter la cellule SIG de Vélo & Territoires à cette adresse : sig@velo-territoires.org
 
 
 ## Publication
@@ -52,8 +51,7 @@ Dans le but de maintenir à jour un répertoire consolidé des aménagements cyc
 Elles peuvent ajouter le mot-clef "aménagement cyclable" lors de la publication du jeu de données dans leur espace de publication ou directement sur data.gouv.fr.
 Les producteurs pourront :
 - publier directement sur data.gouv.fr ;
-- déléguer la publication des données à Vélo & Territoires si les données ont été saisie sur leur WebSIG ;
-- demander à Géovélo de convertir leurs données vers le schéma national si elle
+- demander à Géovélo de convertir leurs données vers le schéma national ;
 - publier sur OpenStreetMap et Géovélo se chargera de la publication avec une conversion vers le schéma.
 
 Nous préconisons aux producteurs de données de publier leurs fichiers avec la règle de nommage suivante : `amenagementcyclable_nom.geojson` avec nom étant le nom de la collectivité productrice des données, par exemple `amenagementcyclable_ain.geojson`. Nous invitons également les producteurs de données à sélectionner "schéma d'aménagements cyclables" dans la liste déroulante de la section "schema" sur data.gouv.fr lorsqu'ils publieront leurs fichiers.
@@ -67,7 +65,7 @@ Cette base de données ainsi construite est issue de l’assemblage de fichiers 
 Trois bases seront publiées sur transport.data.gouv.fr :
 - une base nationale regroupant les données publiées par les collectivités sur data.gouv.fr ;
 - une [base rassemblant les données publiées sur OSM](https://transport.data.gouv.fr/datasets/amenagements-cyclables-france-metropolitaine/). Géovélo sera en charge de l'extraction de ces données et de leur mise à jour mensuelle ;
-- une base nationale consolidant les données publiées par les collectivités sur data.gouv.ft et celles publiées sur OSM. 
+- une base nationale consolidant les données publiées par les collectivités sur data.gouv.fr et celles publiées sur OSM. Cette base est hébergée par Vélo & Territoires et accessible via une carte en ligne à l'adresse suivante : [Velodatamap - carte aménagements](https://velodatamap.velo-territoires.org/vmap/dashboard/map?map_id=14).
 
 
 ## Mise à jour

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Les jeux de données seront publiés au format GeoJSON. Certains champs sont obl
 
 Les producteurs pourront saisir leurs données sur :
 - des outils internes ;
-- OpenStreetMap (OSM); 
+- [OpenStreetMap](https://www.openstreetmap.org) (OSM);
 - les outils développés par Vélo & Territoires à savoir :
     - Un [gabarit au format shapefile](https://github.com/etalab/schema-amenagements-cyclables/blob/master/tools/AC_TEMPLATE_SHP_QGIS.zip) pour QGIS ;
     - Un [script SQL pour la création d’une base de données Postgres/PostGIS](https://github.com/etalab/schema-amenagements-cyclables/blob/master/tools/AC_SQL_POSTGIS.zip) « vierge ».
@@ -52,9 +52,9 @@ Elles peuvent ajouter le mot-clef "aménagement cyclable" lors de la publication
 Les producteurs pourront :
 - publier directement sur data.gouv.fr ;
 - demander à Géovélo de convertir leurs données vers le schéma national ;
-- publier sur OpenStreetMap et Géovélo se chargera de la publication avec une conversion vers le schéma.
+- publier directement sur OpenStreetMap afin que Géovélo se charge de la conversion vers le schéma national et de la publication sur data.gouv.fr.
 
-Nous préconisons aux producteurs de données de publier leurs fichiers avec la règle de nommage suivante : `amenagementcyclable_nom.geojson` avec nom étant le nom de la collectivité productrice des données, par exemple `amenagementcyclable_ain.geojson`. Nous invitons également les producteurs de données à sélectionner "schéma d'aménagements cyclables" dans la liste déroulante de la section "schema" sur data.gouv.fr lorsqu'ils publieront leurs fichiers.
+Nous préconisons aux producteurs de données de publier leurs fichiers avec la règle de nommage suivante : `amenagementcyclable_nom.geojson` avec nom étant le nom de la collectivité productrice des données, par exemple `amenagementcyclable_ain.geojson`. **Nous invitons également les producteurs de données à sélectionner "schéma d'aménagements cyclables" dans la liste déroulante de la section "schema" sur data.gouv.fr lorsqu'ils publieront leurs fichiers.**
 
 En cas de mise à jour d’un fichier déjà intégré à la base consolidée, il est recommandé de prévenir l’équipe transport.data.gouv.fr qui s’assurera de l'actualisation du fichier en question et de son intégration dans la base consolidée à l'adresse : contact@transport.beta.gouv.fr
 

--- a/schema_amenagements_cyclables.json
+++ b/schema_amenagements_cyclables.json
@@ -23,9 +23,15 @@
                 }
             ],
             "created": "2020-12-10",
-            "lastModified": "2023-03-28",
-            "version": "0.3.4",
+            "lastModified": "2024-10-04",
+            "version": "0.3.5",
             "contributors": [
+                {
+                    "title": "Stéphane Pignal",
+                    "email": "contact@transport.data.gouv.fr",
+                    "organisation": "Transport.data.gouv.fr",
+                    "role": "contributor"
+                },
                 {
                     "title": "Miryad Ali",
                     "email": "contact@transport.beta.gouv.fr",


### PR DESCRIPTION
Suite à l'échange avec @stephane-pignal, voici une mise à jour de certaines informations obsolètes concernant Vélo & Territoires et ses actions autour du schéma aménagements cyclables.